### PR TITLE
libstagefright: use 64-bit usage for native_window_set_usage

### DIFF
--- a/media/libstagefright/SurfaceUtils.cpp
+++ b/media/libstagefright/SurfaceUtils.cpp
@@ -111,8 +111,9 @@ status_t setNativeWindowSizeFormatAndUsage(
         }
     }
 
-    int finalUsage = usage | consumerUsage;
-    ALOGV("gralloc usage: %#x(producer) + %#x(consumer) = %#x", usage, consumerUsage, finalUsage);
+    uint64_t finalUsage = (usage | consumerUsage) & 0xffffffffLL;
+    ALOGV("gralloc usage: %#x(producer) + %#x(consumer) = %#" PRIx64,
+            usage, consumerUsage, finalUsage);
     err = native_window_set_usage(nativeWindow, finalUsage);
     if (err != NO_ERROR) {
         ALOGE("native_window_set_usage failed: %s (%d)", strerror(-err), -err);
@@ -126,7 +127,7 @@ status_t setNativeWindowSizeFormatAndUsage(
         return err;
     }
 
-    ALOGD("set up nativeWindow %p for %dx%d, color %#x, rotation %d, usage %#x",
+    ALOGD("set up nativeWindow %p for %dx%d, color %#x, rotation %d, usage %#" PRIx64,
             nativeWindow, width, height, format, rotation, finalUsage);
     return NO_ERROR;
 }


### PR DESCRIPTION
Since Android 8.1 native_window_set_usage has changed to use 64-bit int
for the usage parameter. Use of 32-bit signed integer as parameter does
implicit conversion which may cause unexpected behaviour.

This change fixes errors like:
GrallocMapperPassthrough: buffer descriptor with invalid usage bits 0xffffffff00002000
GraphicBufferAllocator: Failed to allocate (1920 x 1080) layerCount 1 format 2141391875 usage ffffffff80402900: 3

Original 64-bit usage commit:
https://android.googlesource.com/platform/frameworks/native/+/cb496acbe593326e8d5d563847067d02b2df40ec

Tested. Compiled, booted, all works correctly.