### PR TITLE
libcameraservice: fix HAX for depth sensor on ginkgo

### DIFF
--- a/services/camera/libcameraservice/device3/hidl/HidlCamera3Device.cpp
+++ b/services/camera/libcameraservice/device3/hidl/HidlCamera3Device.cpp
@@ -187,7 +187,7 @@ status_t HidlCamera3Device::initialize(sp<CameraProviderManager> manager,
                 physicalId = "20";
                 CLOGW("Trying physical camera %s if available", physicalId.c_str());
                 res = manager->getCameraCharacteristics(
-                        physicalId, false, &mPhysicalDeviceInfoMap[physicalId]);
+                        physicalId, false, &mPhysicalDeviceInfoMap[physicalId], true);
                 if (res != OK) {
                     SET_ERR_L("Could not retrieve camera %s characteristics: %s (%d)",
                             physicalId.c_str(), strerror(-res), res);


### PR DESCRIPTION
* updated for android 13 QPR2
* fix error: too few arguments to function call, expected 4, have 3 physicalId, false, &mPhysicalDeviceInfoMap[physicalId]);